### PR TITLE
Fixing missed context of footer partial, adding socialIcons from config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -77,4 +77,15 @@ theme = "timer-hugo"
         title   = "Latest Works"
         subtitle= "Aliquam lobortis. Maecenas vestibulum mollis diam. Pellentesque auctor neque nec urna. Nulla sit amet est. Aenean posuere tortor sed cursus feugiat, nunc augue blandit nunc, eu sollicitudin urna dolor sagittis lacus."
 
-    
+    [params.footer]
+        [[params.footer.socialIcon]]
+            icon = "ion-social-facebook"
+            url = "#"
+
+        [[params.footer.socialIcon]]
+            icon = "ion-social-instagram"
+            url = "#"
+
+        [[params.footer.socialIcon]]
+            icon = "ion-social-linkedin"
+            url = "#"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,4 +10,4 @@
 
 {{ partial "cta.html" . }}
 
-{{ partial "footer.html" }}
+{{ partial "footer.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,26 +15,9 @@
             <div class="col-md-4 col-12">
                 {{ "<!-- Social Media -->" | safeHTML }}
                 <ul class="social text-center text-md-right text-lg-right">
-                    <li>
-                        <a href="#" class="facebook">
-                            <i class="ion-social-facebook"></i>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="twitter">
-                            <i class="ion-social-twitter"></i>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="linkedin">
-                            <i class="ion-social-linkedin"></i>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="googleplus">
-                            <i class="ion-social-googleplus"></i>
-                        </a>
-                    </li>
+                    {{ range .Site.Params.footer.socialIcon }}
+                    <li><a href="{{ .url }}"><i class="{{ .icon }}"></i></a></li>
+                    {{ end }}
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
The context for footer partial was fixed on PR https://github.com/themefisher/timer-hugo/pull/2
But then reverted at some point mistakenly I believe.
This PR will fix that, and also make social icons in footers to be configurable in configs.toml.
