### PR TITLE
change http to https

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,6 +1,6 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,300,100,500,700);
-@import url(http://fonts.googleapis.com/css?family=Roboto+Condensed:400,300,700);
-@import url(http://fonts.googleapis.com/css?family=Glegoo);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,300,100,500,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto+Condensed:400,300,700);
+@import url(https://fonts.googleapis.com/css?family=Glegoo);
 
 body {
   font-family: "Roboto", sans-serif;


### PR DESCRIPTION
Hello.

I want to add another google font.
But, when I add my CSS file to this theme, Mixed Content problem is occured.

> Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure stylesheet '<URL>'. This request has been blocked; the content must be served over HTTPS.

https://developers.google.com/web/fundamentals/security/prevent-mixed-content/fixing-mixed-content
Maybe that is solution...
Could you change google fonts http -> https?

Happy New Year!