### PR TITLE
Use https for font imports

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,6 +1,6 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,300,100,500,700);
-@import url(http://fonts.googleapis.com/css?family=Roboto+Condensed:400,300,700);
-@import url(http://fonts.googleapis.com/css?family=Glegoo);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,300,100,500,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto+Condensed:400,300,700);
+@import url(https://fonts.googleapis.com/css?family=Glegoo);
 
 body {
   font-family: "Roboto", sans-serif;


### PR DESCRIPTION
This allows it to be used within a https site, such as when hosted via GitHub pages.