### PR TITLE
Make CTA url relative to root

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -83,7 +83,7 @@ enable = true
 title = "SO WHAT YOU THINK ?"
 content = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nobis,<br>possimus commodi, fugiat magnam temporibus vero magni recusandae? Dolore, maxime praesentium."
 btnText = "Contact with me"
-btnURL = "contact/"
+btnURL = "/contact"
 
 # Portfolio Section On Homepage
 [params.portfolio]


### PR DESCRIPTION
CTA url was relative to current page, causing it to refer to non-existing pages such as `about/contact`. By making it relative to the root, it always refers to the correct page